### PR TITLE
Add trailing slash to COPY command

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -19,7 +19,7 @@ RUN export CP_SHA1=198d96c8d7bfafb1ab6df96653c29701510b833c && \
     rm /tmp/containerpilot.tar.gz
 
 COPY containerpilot.json /etc/containerpilot/
-COPY reload-nginx.sh /bin
+COPY reload-nginx.sh /bin/
 COPY index.html /usr/share/nginx/html/
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY nginx.conf.ctmpl /etc/containerpilot/


### PR DESCRIPTION
For https://github.com/autopilotpattern/hello-world/issues/7

This is a workaround for https://devhub.joyent.com/jira/browse/DOCKER-918, which prevents `docker build` on Triton from copying files to a directory when no trailing slash is used. The fix for DOCKER-918 has been merged in https://github.com/joyent/sdc-docker-build/commit/cf9195ef74c689b09ae7874b16e44435cb7fe71b but not deployed cloud-wide yet.

cc @heyawhite @geek for review