### PR TITLE
Use docker-compose configuration version 3 to fix hello-world

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,22 @@
-nginx:
-    build: nginx/
-    ports:
-      - "80:80"
-    links:
-      - consul:consul
-    restart: always
-hello:
-    build: hello/
-    links:
-      - consul:consul
-world:
-    build: world/
-    links:
-      - consul:consul
-consul:
-    image: consul:latest
-    restart: always
-    ports:
-      - "8500:8500"
+version: "3"
+services:
+    nginx:
+        build: nginx/
+        ports:
+          - "80:80"
+        links:
+          - consul:consul
+        restart: always
+    hello:
+        build: hello/
+        links:
+          - consul:consul
+    world:
+        build: world/
+        links:
+          - consul:consul
+    consul:
+        image: consul:latest
+        restart: always
+        ports:
+          - "8500:8500"


### PR DESCRIPTION
On a boot2docker instance through docker-machine from Docker Toolbox, the instructions on autopilotpattern/hello-world resulted in a page that displayed the following

404 Not Found
nginx/1.10.1

404 Not Found
nginx/1.10.1

Solution:
Change the docker-compose.yml to version 3 of the file format.

With this change, the output is

Hello World

which is the expected output.

Why does this work?:
This explanation is based on empirical evidence rather than any deep knowledge of the inner workings of docker-compose.

version "3" of the docker-compose configuration seems to handle networks differently. As a consequence this seems to fix the dns issue.